### PR TITLE
Fix chat by adding proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,14 @@ VITE_OPENAI_API_KEY=your-api-key
 ```
 
 The `.env` file is ignored by Git so your API key remains private. See `.env.example` for the expected variable name.
+
+## Running the development server
+
+Two processes are required: one for the Vite dev server and one for the API proxy.
+
+```bash
+npm run server    # starts the proxy on http://localhost:3001
+npm run dev       # starts the Vite dev server
+```
+
+The front-end proxies `/api` requests to the Node server which communicates with OpenAI, avoiding browser CORS issues.

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "lucide-react": "^0.513.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "express": "^4.19.2",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,57 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.post('/api/chat', async (req, res) => {
+  const { prompt, isJson } = req.body;
+  if (!prompt) return res.status(400).json({ error: 'Missing prompt' });
+
+  const apiKey = process.env.VITE_OPENAI_API_KEY;
+  if (!apiKey) return res.status(500).json({ error: 'API key not configured' });
+
+  const payload = {
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0.7
+  };
+  if (isJson) {
+    payload.response_format = { type: 'json_object' };
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errText = await response.text();
+      console.error('OpenAI API error:', errText);
+      return res.status(response.status).json({ error: 'OpenAI API request failed' });
+    }
+
+    const result = await response.json();
+    const text = result.choices?.[0]?.message?.content?.trim();
+    if (!text) return res.status(500).json({ error: 'Empty response from OpenAI' });
+
+    res.json({ text });
+  } catch (err) {
+    console.error('Proxy error:', err);
+    res.status(500).json({ error: 'Failed to fetch from OpenAI' });
+  }
+});
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`API proxy listening on ${port}`);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,27 +3,11 @@ import { BookOpen, BrainCircuit, Sigma, Puzzle, Wand2, LoaderCircle } from 'luci
 
 // --- Helper for OpenAI ChatGPT API Calls ---
 const callOpenAIAPI = async (prompt, isJson = false) => {
-    const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
-    const apiUrl = 'https://api.openai.com/v1/chat/completions';
-
-    const payload = {
-        model: 'gpt-4o',
-        messages: [{ role: 'user', content: prompt }],
-        temperature: 0.7,
-    };
-
-    if (isJson) {
-        payload.response_format = { type: 'json_object' };
-    }
-
     try {
-        const response = await fetch(apiUrl, {
+        const response = await fetch('/api/chat', {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${apiKey}`,
-            },
-            body: JSON.stringify(payload),
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt, isJson }),
         });
 
         if (!response.ok) {
@@ -33,7 +17,7 @@ const callOpenAIAPI = async (prompt, isJson = false) => {
         }
 
         const result = await response.json();
-        const text = result.choices?.[0]?.message?.content?.trim();
+        const text = result.text?.trim();
         if (!text) {
             throw new Error('No content received from API.');
         }

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- add a small Express proxy so the frontend can talk to OpenAI
- wire Vite dev server to proxy `/api` requests
- update React app to call the new proxy endpoint
- document running the proxy server

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684307a2c45883209ee513fe06a75425