### PR TITLE
Add combined dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Two processes are required: one for the Vite dev server and one for the API prox
 ```bash
 npm run server    # starts the proxy on http://localhost:3001
 npm run dev       # starts the Vite dev server
+# or run both together
+npm start
 ```
 
 The front-end proxies `/api` requests to the Node server which communicates with OpenAI, avoiding browser CORS issues.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "start": "node server.js & vite",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- add a `start` script that launches the API proxy and Vite together
- document `npm start` in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68430aa6d28c83209968d14badcb773d