### PR TITLE
Add enter key handler in chat input

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -333,7 +333,7 @@ const ChatBox = ({ isVisible, onClose, currentQuestion }) => {
                             type="text"
                             value={input}
                             onChange={(e) => setInput(e.target.value)}
-                            onKeyPress={(e) => e.key === 'Enter' && handleSend()}
+                            onKeyDown={(e) => e.key === 'Enter' && handleSend()}
                             placeholder="질문을 입력하세요..."
                             className="flex-1 px-4 py-2 border border-gray-300 rounded-l-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                             disabled={isLoading}


### PR DESCRIPTION
## Summary
- trigger `handleSend` when Enter is pressed in ChatBox

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684303b5137883208052aedabea80c3a